### PR TITLE
Fixed LocalVariableNameGenerator for anonymous classes

### DIFF
--- a/src/main/java/net/amygdalum/testrecorder/deserializers/LocalVariableNameGenerator.java
+++ b/src/main/java/net/amygdalum/testrecorder/deserializers/LocalVariableNameGenerator.java
@@ -43,8 +43,17 @@ public class LocalVariableNameGenerator {
 		if (clazz.isArray()) {
 			return base(clazz.getComponentType()) + "_";
 		} else {
-			String simpleName = clazz.getSimpleName();
+			String simpleName = findSimpleName(clazz);
 			return toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
 		}
+	}
+
+	private String findSimpleName(Class<?> clazz) {
+		String simpleName = clazz.getSimpleName();
+		if (simpleName.isEmpty()) {
+			String[] parts = clazz.getName().split("\\.");
+			simpleName = parts[parts.length - 1] + "_";
+		}
+		return simpleName;
 	}
 }

--- a/src/test/java/net/amygdalum/testrecorder/deserializers/LocalVariableNameGeneratorTest.java
+++ b/src/test/java/net/amygdalum/testrecorder/deserializers/LocalVariableNameGeneratorTest.java
@@ -1,0 +1,44 @@
+package net.amygdalum.testrecorder.deserializers;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class LocalVariableNameGeneratorTest {
+
+	@Test
+	public void generatesNameForTypes() {
+		LocalVariableNameGenerator nameGenerator = new LocalVariableNameGenerator();
+		String testName = nameGenerator.fetchName(SimpleEnum.class);
+		assertThat(testName, is(equalTo("simpleEnum1")));
+	}
+
+	@Test
+	public void generatesNameForAnonymousTypes() {
+		LocalVariableNameGenerator nameGenerator = new LocalVariableNameGenerator();
+		String testName = nameGenerator.fetchName(SimpleEnum.enum1.getClass());
+		assertThat(testName, is(equalTo("simpleEnum1")));
+
+		testName = nameGenerator.fetchName(SmartEnum.enum1.getClass());
+		assertThat(testName, is(equalTo("smartEnum$1_1")));
+	}
+
+}
+
+enum SimpleEnum {
+	enum1;
+}
+
+enum SmartEnum {
+	enum1 {
+
+		@Override
+		void overrideMe() {
+			// Causes $1 class
+		}
+	};
+
+	abstract void overrideMe();
+}


### PR DESCRIPTION
Hi there, I ran into an exception when I instrumented code with anonymous classes (which don't have a simple class name). This commit includes a test reproducing my scenario closely, I'm sure the test could be extended or generalised.
